### PR TITLE
use %CONNECTURL% available since JARVICE 3.0.0-1.202008112237

### DIFF
--- a/nimbix_desktop/help-real.html
+++ b/nimbix_desktop/help-real.html
@@ -1,5 +1,5 @@
 <h1>
-    <a href="https://%PUBLICADDR%/vnc.html?host=%PUBLICADDR%&port=443&password=%NIMBIXPASSWD%&autoconnect=true&reconnect=true"
+    <a href="%CONNECTURL%"
        target="%JOBNAME%">Click Here to Connect</a></h1>
 <p>
     Alternatively, you may connect securely with a Real VNC&reg; client:

--- a/nimbix_desktop/help-tiger.html
+++ b/nimbix_desktop/help-tiger.html
@@ -1,5 +1,5 @@
 <h1>
-    <a href="https://%PUBLICADDR%/vnc.html?host=%PUBLICADDR%&port=443&password=%NIMBIXPASSWD%&autoconnect=true&reconnect=true"
+    <a href="%CONNECTURL%"
        target="%JOBNAME%">Click Here to Connect</a></h1>
 <p>
     Alternatively, you may connect securely with a TigerVNC client:


### PR DESCRIPTION
use the new %CONNECTURL% construct which will properly map ingress on JXE, and broker on Nimbix Cloud.